### PR TITLE
test pubkeys from SSH_AUTH_INFO_0 against authorized_keys.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,4 +4,4 @@
 * Jan-Pieter Cornet ( johnpc ) - 2012-03-23 03:25:52 PDT
 * chrysn@fsfe.org
 * dfberger@users.noreply.github.com
-
+* lizf@honeycomb.io

--- a/Makefile.in
+++ b/Makefile.in
@@ -74,7 +74,7 @@ SSHOBJS=xmalloc.o atomicio.o authfd.o bufaux.o bufbn.o buffer.o cleanup.o entrop
 
 ED25519OBJS=ed25519-donna/ed25519.o
 
-PAM_SSH_AGENT_AUTH_OBJS=pam_user_key_allowed2.o iterate_ssh_agent_keys.o userauth_pubkey_from_id.o pam_user_authorized_keys.o get_command_line.o
+PAM_SSH_AGENT_AUTH_OBJS=pam_user_key_allowed2.o iterate_ssh_agent_keys.o userauth_pubkey_from_id.o pam_user_authorized_keys.o get_command_line.o userauth_pubkey_from_pam.o
 
 
 MANPAGES_IN	= pam_ssh_agent_auth.pod

--- a/pam_ssh_agent_auth.c
+++ b/pam_ssh_agent_auth.c
@@ -57,6 +57,7 @@
 #include "ssh.h"
 #include "pam_static_macros.h"
 #include "pam_user_authorized_keys.h"
+#include "userauth_pubkey_from_pam.h"
 
 #define strncasecmp_literal(A,B) strncasecmp( A, B, sizeof(B) - 1)
 #define UNUSED(expr) do { (void)(expr); } while (0)
@@ -190,10 +191,23 @@ pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc, const char **argv)
         pamsshagentauth_verbose("Attempting authentication: `%s' as `%s' using %s", ruser, user, authorized_keys_file);
 
         /*
+         * Attempt to read data from the sshd if we're being called as an auth agent.
+         */
+        const char* ssh_user_auth = pam_getenv(pamh, "SSH_AUTH_INFO_0");
+        if (ssh_user_auth != NULL) {
+            pamsshagentauth_verbose("Got SSH_AUTH_INFO_0: `%.20s...%.20s'", ssh_user_auth, ssh_user_auth + (strlen(ssh_user_auth) - 20));
+            if (userauth_pubkey_from_pam(ruser, ssh_user_auth) > 0) {
+                retval = PAM_SUCCESS;
+                pamsshagentauth_logit("Authenticated (sshd): `%s' as `%s' using %s", ruser, user, authorized_keys_file);
+                goto cleanexit;
+            }
+        }
+
+        /*
          * this pw_uid is used to validate the SSH_AUTH_SOCK, and so must be the uid of the ruser invoking the program, not the target-user
          */
         if(pamsshagentauth_find_authorized_keys(user, ruser, servicename)) { /* getpwnam(ruser)->pw_uid)) { */
-            pamsshagentauth_logit("Authenticated: `%s' as `%s' using %s", ruser, user, authorized_keys_file);
+            pamsshagentauth_logit("Authenticated (agent): `%s' as `%s' using %s", ruser, user, authorized_keys_file);
             retval = PAM_SUCCESS;
         } else {
             pamsshagentauth_logit("Failed Authentication: `%s' as `%s' using %s", ruser, user, authorized_keys_file);

--- a/pam_ssh_agent_auth.c
+++ b/pam_ssh_agent_auth.c
@@ -82,6 +82,7 @@ pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc, const char **argv)
     char           *servicename = NULL;
     char           *authorized_keys_file_input = NULL;
     char            sudo_service_name[128] = "sudo";
+    char            sshd_service_name[128] = "sshd";
     char            ruser[128] = "";
 
     int             i = 0;
@@ -194,7 +195,8 @@ pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc, const char **argv)
          * Attempt to read data from the sshd if we're being called as an auth agent.
          */
         const char* ssh_user_auth = pam_getenv(pamh, "SSH_AUTH_INFO_0");
-        if (ssh_user_auth != NULL) {
+        int sshd_service = strncasecmp(servicename, sshd_service_name, sizeof(sshd_service_name) - 1);
+        if (sshd_service == 0 && ssh_user_auth != NULL) {
             pamsshagentauth_verbose("Got SSH_AUTH_INFO_0: `%.20s...'", ssh_user_auth);
             if (userauth_pubkey_from_pam(ruser, ssh_user_auth) > 0) {
                 retval = PAM_SUCCESS;

--- a/pam_ssh_agent_auth.c
+++ b/pam_ssh_agent_auth.c
@@ -195,7 +195,7 @@ pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc, const char **argv)
          */
         const char* ssh_user_auth = pam_getenv(pamh, "SSH_AUTH_INFO_0");
         if (ssh_user_auth != NULL) {
-            pamsshagentauth_verbose("Got SSH_AUTH_INFO_0: `%.20s...%.20s'", ssh_user_auth, ssh_user_auth + (strlen(ssh_user_auth) - 20));
+            pamsshagentauth_verbose("Got SSH_AUTH_INFO_0: `%.20s...'", ssh_user_auth);
             if (userauth_pubkey_from_pam(ruser, ssh_user_auth) > 0) {
                 retval = PAM_SUCCESS;
                 pamsshagentauth_logit("Authenticated (sshd): `%s' as `%s' using %s", ruser, user, authorized_keys_file);

--- a/pam_ssh_agent_auth.pod
+++ b/pam_ssh_agent_auth.pod
@@ -4,13 +4,16 @@ pam_ssh_agent_auth - PAM module for granting permissions based on SSH agent requ
 
 =head1 DESCRIPTION
 
-This module provides authentication via ssh-agent.  If an ssh-agent listening at SSH_AUTH_SOCK can successfully authenticate that it has the secret key for a public key in the specified file, authentication is granted, otherwise authentication fails.
+This module provides authentication via ssh keys.  If an ssh-agent listening at SSH_AUTH_SOCK can successfully authenticate that it has the secret key for a public key in the specified file, authentication is granted.  If the public key originally used to authenticate at sshd matches an authorized key, authentication succeeds.  Otherwise authentication fails.
 
 =head1 CONFIGURATION
+
+=head2 SUDO
 
 =over
 
 =item /etc/pam.d/sudo:
+
  auth	sufficient	pam_ssh_agent_auth.so file=/etc/security/authorized_keys
 
 =item /etc/sudoers:
@@ -24,6 +27,28 @@ This configuration would permit anyone who has an SSH_AUTH_SOCK that manages the
 
 Unlike NOPASSWD, this still requires an authentication, it's just that the authentication is provided by ssh-agent, and not password entry. 
 
+=head2 SSHD
+
+=over
+
+=item /etc/ssh/sshd_config:
+
+ PubkeyAuthentication yes
+ AuthenticationMethods publickey,keyboard-interactive:pam
+ PasswordAuthentication no
+ UsePAM yes
+
+=item /etc/pam.d/sshd:
+
+ auth required    pam_permit.so
+ auth	sufficient	pam_ssh_agent_auth.so file=/etc/security/super_authorized_keys
+ auth sufficient  pam_secondary_auth_method.so
+ ...
+ auth requisite   pam_deny.so
+
+=back
+
+This configuration would permit anyone who originally authenticated to sshd with a public key also found in /etc/security/super_authorized_keys to log in without having to complete other PAM auth methods. Anyone whose ssh key was accepted initially by sshd but whose key is not in the allowlist must complete another secondary PAM module such as OTP or else be denied.
 
 =head1 ARGUMENTS
 
@@ -132,7 +157,7 @@ For more information, please see http://linux.die.net/man/5/pam.d
 
  Copyright (c) 2008-2014, Jamie Beverly.
  And is based on openssh, and the included works by Markus Friedl, Darren Tucker,
- Todd C. Miller, Ben Lindstrom, Tim Rice, Damien Miller, and many others.
+ Todd C. Miller, Ben Lindstrom, Tim Rice, Damien Miller, Liz Fong-Jones, and many others.
 
  All rights reserved.
 

--- a/userauth_pubkey_from_pam.c
+++ b/userauth_pubkey_from_pam.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019, Hound Technology, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ * 
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ * 
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY Jamie Beverly ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Jamie Beverly OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of Liz Fong-Jones or Hound Technology, Inc.
+ */
+
+#include "userauth_pubkey_from_pam.h"
+#include "config.h"
+
+#include <string.h>
+
+#include "defines.h"
+#include "key.h"
+#include "log.h"
+
+#include "pam_user_authorized_keys.h"
+
+int userauth_pubkey_from_pam(const char* ruser, const char* ssh_auth_info) {
+    int authenticated = 0;
+    const char* method = "publickey ";
+
+    char* ai = strdup(ssh_auth_info);
+    char* saveptr;
+    if (ai == NULL) {
+        return authenticated;
+    }
+
+    char* auth_line = strtok_r(ai, "\n", &saveptr);
+    while (auth_line != NULL) {
+        if (strncmp(auth_line, method, strlen(method)) == 0) {
+            char* key_str = auth_line + strlen(method);
+            Key* key = pamsshagentauth_key_new(KEY_UNSPEC);
+            if (key == NULL) {
+                continue;
+            }
+            int r = 0;
+            if ((r = pamsshagentauth_key_read(key, &key_str)) == 1) {
+                if (pam_user_key_allowed(ruser, key)) {
+                    authenticated = 1;
+                }
+            } else {
+                pamsshagentauth_verbose("Failed to create key for %s: %d", auth_line, r);
+            }
+            pamsshagentauth_key_free(key);
+        }
+        auth_line = strtok_r(NULL, "\n", &saveptr);
+    }
+
+    free(ai);
+    return authenticated;
+}
+

--- a/userauth_pubkey_from_pam.h
+++ b/userauth_pubkey_from_pam.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019, Hound Technology, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ * 
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ * 
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY Jamie Beverly ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Jamie Beverly OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of Liz Fong-Jones or Hound Technology, Inc.
+ */
+
+
+#ifndef _USERAUTH_PUBKEY_FROM_PAM_H
+#define _USERAUTH_PUBKEY_FROM_PAM_H
+
+int userauth_pubkey_from_pam(const char* ruser, const char* ssh_auth_info);
+
+#endif


### PR DESCRIPTION
If `SSH_AUTH_INFO_0` is present in the PAM environment (which openssh-7.6 and newer will do for `session` and `account`, and patched openssh will also do for `auth`), then check the already-validated public key(s) from the `publickey` method against our list of keys authorized for this PAM module.

Addresses #14.