### PR TITLE
Handle PAM_RUSER and PAM_USER being identical

### DIFF
--- a/pam_ssh_agent_auth.c
+++ b/pam_ssh_agent_auth.c
@@ -168,9 +168,19 @@ pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc, const char **argv)
         pamsshagentauth_verbose("getpwnam(%s) failed, bailing out", ruser);
         goto cleanexit;
     }
-    if( ! getpwnam(user) ) {
+    if(! getpwnam(user) ) {
         pamsshagentauth_verbose("getpwnam(%s) failed, bailing out", user);
         goto cleanexit;
+    }
+
+    if(strcmp(ruser, user) == 0) {
+        pamsshagentauth_verbose("ruser and user are identical (%s), this is weird", ruser);
+        if (allow_user_owned_authorized_keys_file) {
+            pamsshagentauth_verbose(
+              "ruser and user are identical (%s) and 'allow_user_owned_authorized_keys_file' "
+              "is enabled at the same time. This grants the user arbitrary access, bailing out.", ruser);
+            goto cleanexit;
+        }
     }
 
     if(authorized_keys_file_input && user) {


### PR DESCRIPTION
Warns if PAM_RUSER and PAM_USER are identical. Bails out if additionally
allow_user_owned_authorized_keys_file is enabled.
If authorized_keys_file is allowed to be owned by user, and user is identical
with ruser, this means that the calling user (i.e. ruser) can add arbitrary keys
to it, thus rendering the whole PAM step useless.

Fixes #17, but will cause the module to stop working in the described situation.
This is fine, as in this scenario, this module poses a massive security gap.