### PR TITLE
man: Remove misleading information about env_keep

### DIFF
--- a/pam_ssh_agent_auth.pod
+++ b/pam_ssh_agent_auth.pod
@@ -18,8 +18,9 @@ This module provides authentication via ssh keys.  If an ssh-agent listening at 
 
 =item /etc/sudoers:
  
-In older versions of sudo (< 1.8.5) it was necessary to set:
- Defaults    env_keep += "SSH_AUTH_SOCK"
+Enable sudo to pass environment variable pointing to the ssh authentication socket:
+
+  Defaults    env_keep += "SSH_AUTH_SOCK"
 
 =back
 


### PR DESCRIPTION
This configuration option is always needed also with the current sudo.