### PR TITLE
add argument: default_ssh_auth_sock and some fixes

### DIFF
--- a/authfd.c
+++ b/authfd.c
@@ -157,6 +157,7 @@ ssh_get_authentication_socket(uid_t uid)
 		close(sock);
         if(errno == EACCES)
             pamsshagentauth_fatal("MAJOR SECURITY WARNING: uid %lu made a deliberate and malicious attempt to open an agent socket owned by another user", (unsigned long) uid);
+		seteuid(0);
 		return -1;
 	}
 

--- a/authfd.c
+++ b/authfd.c
@@ -72,6 +72,7 @@
 #include "misc.h"
 
 extern char *default_ssh_auth_sock;
+extern uint8_t ignore_env_ssh_auth_sock;
 
 static int agent_present = 0;
 
@@ -112,7 +113,7 @@ ssh_get_authentication_socket(uid_t uid)
     struct stat sock_st;
 
 	authsocket = getenv(SSH_AUTHSOCKET_ENV_NAME);
-	authsocket = authsocket ? authsocket : default_ssh_auth_sock;
+	authsocket = authsocket && !ignore_env_ssh_auth_sock ? authsocket : default_ssh_auth_sock;
 	if (!authsocket)
 		return -1;
 
@@ -226,7 +227,7 @@ ssh_close_authentication_socket(int sock)
 	const char *authsocket;
 
 	authsocket = getenv(SSH_AUTHSOCKET_ENV_NAME);
-	authsocket = authsocket ? authsocket : default_ssh_auth_sock;
+	authsocket = authsocket && !ignore_env_ssh_auth_sock ? authsocket : default_ssh_auth_sock;
   
 	if (authsocket)
 		close(sock);

--- a/authfd.c
+++ b/authfd.c
@@ -71,6 +71,8 @@
 #include "atomicio.h"
 #include "misc.h"
 
+extern char *default_ssh_auth_sock;
+
 static int agent_present = 0;
 
 /* helper */
@@ -110,6 +112,7 @@ ssh_get_authentication_socket(uid_t uid)
     struct stat sock_st;
 
 	authsocket = getenv(SSH_AUTHSOCKET_ENV_NAME);
+	authsocket = authsocket ? authsocket : default_ssh_auth_sock;
 	if (!authsocket)
 		return -1;
 
@@ -220,7 +223,12 @@ ssh_request_reply(AuthenticationConnection *auth, Buffer *request, Buffer *reply
 void
 ssh_close_authentication_socket(int sock)
 {
-	if (getenv(SSH_AUTHSOCKET_ENV_NAME))
+	const char *authsocket;
+
+	authsocket = getenv(SSH_AUTHSOCKET_ENV_NAME);
+	authsocket = authsocket ? authsocket : default_ssh_auth_sock;
+  
+	if (authsocket)
 		close(sock);
 }
 

--- a/pam_ssh_agent_auth.c
+++ b/pam_ssh_agent_auth.c
@@ -28,6 +28,7 @@
  */
 
 #include "config.h"
+#include <security/_pam_types.h>
 #include <syslog.h>
 
 #ifdef HAVE_SECURITY_PAM_APPL_H
@@ -68,6 +69,7 @@ uint8_t         allow_user_owned_authorized_keys_file = 0;
 char           *authorized_keys_command = NULL;
 char           *authorized_keys_command_user = NULL;
 char           *default_ssh_auth_sock = NULL;
+uint8_t         ignore_env_ssh_auth_sock = 0;
 
 #if ! HAVE___PROGNAME || HAVE_BUNDLE
 char           *__progname;
@@ -129,6 +131,9 @@ pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc, const char **argv)
         }
         if(strncasecmp_literal(*argv_ptr, "default_ssh_auth_sock=") == 0 ) {
             default_ssh_auth_sock = *argv_ptr + sizeof("default_ssh_auth_sock=") - 1;
+        }
+        if(strncasecmp_literal(*argv_ptr, "ignore_env_ssh_auth_sock")  == 0) {
+            ignore_env_ssh_auth_sock = 1;
         }
 #ifdef ENABLE_SUDO_HACK
         if(strncasecmp_literal(*argv_ptr, "sudo_service_name=") == 0) {

--- a/pam_ssh_agent_auth.c
+++ b/pam_ssh_agent_auth.c
@@ -58,6 +58,7 @@
 #include "pam_static_macros.h"
 #include "pam_user_authorized_keys.h"
 #include "userauth_pubkey_from_pam.h"
+#include "misc.h"
 
 #define strncasecmp_literal(A,B) strncasecmp( A, B, sizeof(B) - 1)
 #define UNUSED(expr) do { (void)(expr); } while (0)
@@ -175,6 +176,12 @@ pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc, const char **argv)
     if( ! getpwnam(user) ) {
         pamsshagentauth_verbose("getpwnam(%s) failed, bailing out", user);
         goto cleanexit;
+    }
+
+    if(default_ssh_auth_sock && user) {
+       default_ssh_auth_sock = pamsshagentauth_percent_expand(default_ssh_auth_sock,
+       "h", getpwnam(user)->pw_dir,
+       "u", user, NULL);
     }
 
     if(authorized_keys_file_input && user) {

--- a/pam_ssh_agent_auth.c
+++ b/pam_ssh_agent_auth.c
@@ -179,9 +179,17 @@ pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc, const char **argv)
     }
 
     if(default_ssh_auth_sock && user) {
+       uid_t uid = getpwnam(user)->pw_uid;
+       int length = snprintf( NULL, 0, "%u", uid);
+       char* uid_s = malloc( length + 1 );
+       snprintf( uid_s, length + 1, "%u", uid);
+
        default_ssh_auth_sock = pamsshagentauth_percent_expand(default_ssh_auth_sock,
        "h", getpwnam(user)->pw_dir,
+       "U", uid_s,
        "u", user, NULL);
+
+       free(uid_s);
     }
 
     if(authorized_keys_file_input && user) {

--- a/pam_ssh_agent_auth.c
+++ b/pam_ssh_agent_auth.c
@@ -66,6 +66,7 @@ char           *authorized_keys_file = NULL;
 uint8_t         allow_user_owned_authorized_keys_file = 0;
 char           *authorized_keys_command = NULL;
 char           *authorized_keys_command_user = NULL;
+char           *default_ssh_auth_sock = NULL;
 
 #if ! HAVE___PROGNAME || HAVE_BUNDLE
 char           *__progname;
@@ -124,6 +125,9 @@ pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc, const char **argv)
         }
         if(strncasecmp_literal(*argv_ptr, "authorized_keys_command_user=") == 0 ) {
             authorized_keys_command_user = *argv_ptr + sizeof("authorized_keys_command_user=") - 1;
+        }
+        if(strncasecmp_literal(*argv_ptr, "default_ssh_auth_sock=") == 0 ) {
+            default_ssh_auth_sock = *argv_ptr + sizeof("default_ssh_auth_sock=") - 1;
         }
 #ifdef ENABLE_SUDO_HACK
         if(strncasecmp_literal(*argv_ptr, "sudo_service_name=") == 0) {

--- a/pam_ssh_agent_auth.pod
+++ b/pam_ssh_agent_auth.pod
@@ -73,6 +73,10 @@ This is ideally suited for use with sssd's sss_ssh_authorizedkeys, for authentic
 
 Specify a user to run the authorized_keys_command as. If this option is not specified, the authorized_keys_command will be run as the user being authenticated.
 
+=item default_ssh_auth_sock=/path/to/ssh_auth_sock
+
+Specify a default SSH_AUTH_SOCK to use. Useful when logging in with a Display Manager (such as SDDM), in which case environment variables are hard to set.
+
 =item debug
 
 A flag which enables verbose logging

--- a/pam_ssh_agent_auth.pod
+++ b/pam_ssh_agent_auth.pod
@@ -77,6 +77,10 @@ Specify a user to run the authorized_keys_command as. If this option is not spec
 
 Specify a default SSH_AUTH_SOCK to use. Useful when logging in with a Display Manager (such as SDDM), in which case environment variables are hard to set.
 
+=item ignore_env_ssh_auth_sock
+
+A flag which makes SSH_AUTH_SOCK from environment variable ignored and fallback to default_ssh_auth_sock.
+
 =item debug
 
 A flag which enables verbose logging

--- a/pam_ssh_agent_auth.pod
+++ b/pam_ssh_agent_auth.pod
@@ -107,6 +107,8 @@ Automatically enables allow_user_owned_authorized_keys_file
 
 =item %H -- The short-hostname
 
+=item %U -- Uid
+
 =item %u -- Username
 
 =item %f -- FQDN


### PR DESCRIPTION
Useful when `SSH_AUTH_SOCK` can't be set in environment. For example: loging in from a Display Manager (such as SDDM).