### PR TITLE
fixed compilation on macOS 12

### DIFF
--- a/configure
+++ b/configure
@@ -9089,6 +9089,7 @@ else
 /* end confdefs.h.  */
 
 #include <stdio.h>
+#include <stdlib.h>
 int main(){exit(0);}
 
 _ACEOF
@@ -11211,6 +11212,7 @@ else
 /* end confdefs.h.  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <openssl/opensslv.h>
 #define DATA "conftest.sslincver"
@@ -11323,6 +11325,8 @@ else
 /* end confdefs.h.  */
 
 #include <string.h>
+#include <stdlib.h>
+#include <openssl/crypto.h>
 #include <openssl/opensslv.h>
 int main(void) { exit(SSLeay() == OPENSSL_VERSION_NUMBER ? 0 : 1); }
 
@@ -13841,6 +13845,7 @@ else
 /* end confdefs.h.  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #ifdef HAVE_SNPRINTF
 main()
@@ -14838,6 +14843,8 @@ else
 
 	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
+
+#include <stdio.h>
 
 int
 main ()

--- a/key.h
+++ b/key.h
@@ -32,6 +32,14 @@
 #include <openssl/ecdsa.h>
 #include "ed25519-donna/ed25519.h"
 
+#ifndef u_char
+typedef unsigned char   u_char;
+#endif
+
+#ifndef u_int
+typedef unsigned int   u_int;
+#endif
+
 typedef struct Key Key;
 enum types {
 	KEY_RSA1,

--- a/openbsd-compat/bsd-snprintf.c
+++ b/openbsd-compat/bsd-snprintf.c
@@ -827,7 +827,7 @@ fmtfp (char *buffer, size_t *currlen, size_t maxlen,
 }
 #endif /* !defined(HAVE_SNPRINTF) || !defined(HAVE_VSNPRINTF) */
 
-#if !defined(HAVE_VSNPRINTF)
+#ifndef vsnprintf
 int
 vsnprintf (char *str, size_t count, const char *fmt, va_list args)
 {
@@ -835,7 +835,7 @@ vsnprintf (char *str, size_t count, const char *fmt, va_list args)
 }
 #endif
 
-#if !defined(HAVE_SNPRINTF)
+#ifndef snprintf
 int
 snprintf(char *str, size_t count, SNPRINTF_CONST char *fmt, ...)
 {


### PR DESCRIPTION
Fixed compile on macOS 12.
Also fixed spurious "Your OpenSSL headers do not match your library" which was happening on macOS and Linux.