### PR TITLE
Use SHA256 instead of MD5 for key fingerprints

### DIFF
--- a/key.h
+++ b/key.h
@@ -50,6 +50,7 @@ enum fp_type {
 };
 enum fp_rep {
 	SSH_FP_HEX,
+	SSH_FP_BASE64,
 	SSH_FP_BUBBLEBABBLE
 };
 

--- a/pam_user_key_allowed2.c
+++ b/pam_user_key_allowed2.c
@@ -102,7 +102,7 @@ pamsshagentauth_check_authkeys_file(FILE * f, char *file, Key * key)
             found_key = 1;
             pamsshagentauth_logit("matching key found: file/command %s, line %lu", file,
                                   linenum);
-            fp = pamsshagentauth_key_fingerprint(found, SSH_FP_MD5, SSH_FP_HEX);
+            fp = pamsshagentauth_key_fingerprint(found, SSH_FP_SHA256, SSH_FP_BASE64);
             pamsshagentauth_logit("Found matching %s key: %s",
                                   pamsshagentauth_key_type(found), fp);
             pamsshagentauth_xfree(fp);


### PR DESCRIPTION
We ran into problems using this module when running in FIPS mode. MD5 is not allowed with FIPS and in general probably not a good idea to use for key fingerprints anymore.

I propose switching to SHA256 which upstream OpenSSH appears to use by default since [OpenSSH 6.8](https://www.openssh.com/txt/release-6.8). The PR also changes the format of SSH fingerprints from hex encoding to base64 with appended hash name for compatibility with upstream fingerprints.
