### PR TITLE
Always use the compiler to call the linker

### DIFF
--- a/configure
+++ b/configure
@@ -7577,10 +7577,7 @@ _ACEOF
 
 fi
 
-if test -z "$LD" ; then
-	LD=$CC
-fi
-
+LD=$CC
 
 
 ac_fn_c_check_decl "$LINENO" "LLONG_MAX" "ac_cv_have_decl_LLONG_MAX" "#include <limits.h>

--- a/configure.ac
+++ b/configure.ac
@@ -116,11 +116,7 @@ if test ! -z "$PATH_PASSWD_PROG" ; then
 		[Full path of your "passwd" program])
 fi
 
-if test -z "$LD" ; then
-	LD=$CC
-fi
-AC_SUBST(LD)
-
+AC_SUBST(LD, $CC)
 
 AC_CHECK_DECL(LLONG_MAX, have_llong_max=1, , [#include <limits.h>])
 


### PR DESCRIPTION
Building with `LD` defined as `ld.lld` fails with errors such as `ld.lld: error: unknown argument '-Wl,-O1'` (see https://bugs.gentoo.org/741927).  This is because if LD is defined in the environment, it becomes the binary that executes the final link command.  But `LDFLAGS` generally consist of flags prefixed with `-Wl,` that are designed to be passed by the compiler to the linker.  Since linkers don't recognized such prefixed flags, linking fails.

In this context, the build's `LD` should always be `$CC`.  Testing the final link command verbosely shows that the compiler selects the proper linker from the shell environment's `$LD`.